### PR TITLE
 fix: correct GitHub organization case and reorganize code structure

### DIFF
--- a/cmd/chroma/definitions.go
+++ b/cmd/chroma/definitions.go
@@ -9,6 +9,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// ============ Application Setup ============
+
 // createApp builds the root CLI application with all commands and flags.
 // It follows clig.dev guidelines for a consistent, user-friendly CLI experience.
 func createApp() *cli.Command {
@@ -89,6 +91,8 @@ func createApp() *cli.Command {
 		},
 	}
 }
+
+// ============ Command Definitions ============
 
 // pingCommand tests connectivity to the ChromaDB server.
 var pingCommand = &cli.Command{
@@ -338,6 +342,8 @@ EXAMPLES:
 		llmModelFlag,
 	},
 }
+
+// ============ Flag Definitions ============
 
 // Flags
 var (

--- a/cmd/chroma/handlers.go
+++ b/cmd/chroma/handlers.go
@@ -17,7 +17,10 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// ============== Command Handlers ==============
+// ============ Command Handlers ============
+// Handlers are organized by functional domain.
+
+// ===== Connection & Tenant =====
 
 // handleTestConnection tests connectivity to ChromaDB.
 func handleTestConnection(ctx context.Context, cmd *cli.Command) error {
@@ -108,6 +111,8 @@ func handleListDatabases(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
+// ===== Collections =====
+
 // handleListCollection lists collections in the current database.
 func handleListCollection(_ context.Context, cmd *cli.Command) error {
 	slog.Info("Listing collections", "tenant", cmd.String("tenant"), "database", cmd.String("database"))
@@ -197,36 +202,7 @@ func handleDeleteCollection(_ context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-// handleDeleteRecords deletes specific documents from a collection by IDs.
-func handleDeleteRecords(_ context.Context, cmd *cli.Command) error {
-	collectionName := cmd.Args().Get(0)
-	ids := cmd.StringSlice("id")
-
-	if collectionName == "" {
-		return fmt.Errorf("collection name is required\n\nUsage: chroma delete-records <collection> --id <id>\n\nExample: chroma delete-records my_collection --id doc-1")
-	}
-
-	if len(ids) == 0 {
-		return fmt.Errorf("at least one document ID is required\n\nUsage: chroma delete-records <collection> --id <id>")
-	}
-
-	slog.Info("Deleting records", "collection", collectionName, "ids", ids)
-
-	chromaClient, err := createChromaClient(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to create Chroma client: %w", err)
-	}
-
-	if err := chromaClient.DeleteRecords(collectionName, ids); err != nil {
-		slog.Error("Delete records failed", "error", err)
-		return fmt.Errorf("failed to delete records: %w", err)
-	}
-
-	fmt.Printf("✅ Deleted %d document(s) from '%s'\n", len(ids), collectionName)
-	slog.Info("Records deleted", "collection", collectionName, "ids", ids)
-
-	return nil
-}
+// ===== Documents =====
 
 // handleListDocuments lists documents in a collection.
 func handleListDocuments(_ context.Context, c *cli.Command) error {
@@ -285,6 +261,93 @@ func handleListDocuments(_ context.Context, c *cli.Command) error {
 
 	return nil
 }
+
+// handleBatchAddDocuments adds documents to a collection.
+func handleBatchAddDocuments(_ context.Context, c *cli.Command) error {
+	collectionName := c.Args().Get(0)
+	docs := c.StringSlice("doc")
+
+	if len(docs) == 0 {
+		return fmt.Errorf("no documents provided\n\nUsage: chroma add <collection> --doc \"text\"\n\nExample: chroma add my_collection --doc \"Your document\"")
+	}
+
+	// Setup client
+	client, err := createChromaClient(c)
+	if err != nil {
+		return fmt.Errorf("failed to create Chroma client: %w", err)
+	}
+
+	// Load AI Engine
+	embedder, err := initEmbedder(c)
+	if err != nil {
+		return fmt.Errorf("failed to initialize embedding engine: %w\n\nHint: Verify model files exist", err)
+	}
+
+	svc := service.NewChromaService(client, embedder)
+	defer svc.Close()
+
+	// Handle IDs: use provided ones or generate auto IDs
+	ids := c.StringSlice("id")
+	if len(ids) > 0 {
+		// User provided custom IDs
+		if len(ids) != len(docs) {
+			return fmt.Errorf("number of IDs (%d) must match number of documents (%d)", len(ids), len(docs))
+		}
+
+		slog.Info("Using custom document IDs", "ids", ids)
+	} else {
+		// Generate auto IDs
+		ids = make([]string, len(docs))
+		for i := range docs {
+			ids[i] = fmt.Sprintf("id-%d-%d", time.Now().UnixNano(), i)
+		}
+	}
+
+	// Execute
+	slog.Info("Uploading batch to Chroma", "collection", collectionName, "count", len(docs))
+
+	if err := svc.AddDocuments(collectionName, docs, ids); err != nil {
+		return fmt.Errorf("failed to add documents: %w\n\nHint: Check collection exists and you have write permissions", err)
+	}
+
+	fmt.Printf("✅ Successfully added %d documents to '%s'\n", len(docs), collectionName)
+	slog.Info("Documents added", "collection", collectionName, "count", len(docs))
+
+	return nil
+}
+
+// handleDeleteRecords deletes specific documents from a collection by IDs.
+func handleDeleteRecords(_ context.Context, cmd *cli.Command) error {
+	collectionName := cmd.Args().Get(0)
+	ids := cmd.StringSlice("id")
+
+	if collectionName == "" {
+		return fmt.Errorf("collection name is required\n\nUsage: chroma delete-records <collection> --id <id>\n\nExample: chroma delete-records my_collection --id doc-1")
+	}
+
+	if len(ids) == 0 {
+		return fmt.Errorf("at least one document ID is required\n\nUsage: chroma delete-records <collection> --id <id>")
+	}
+
+	slog.Info("Deleting records", "collection", collectionName, "ids", ids)
+
+	chromaClient, err := createChromaClient(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to create Chroma client: %w", err)
+	}
+
+	if err := chromaClient.DeleteRecords(collectionName, ids); err != nil {
+		slog.Error("Delete records failed", "error", err)
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	fmt.Printf("✅ Deleted %d document(s) from '%s'\n", len(ids), collectionName)
+	slog.Info("Records deleted", "collection", collectionName, "ids", ids)
+
+	return nil
+}
+
+// ===== Search & Query =====
 
 // handleQueryBatchInCollection performs batch semantic search.
 func handleQueryBatchInCollection(_ context.Context, c *cli.Command) error {
@@ -358,59 +421,7 @@ func handleQueryBatchInCollection(_ context.Context, c *cli.Command) error {
 	return nil
 }
 
-// handleBatchAddDocuments adds documents to a collection.
-func handleBatchAddDocuments(_ context.Context, c *cli.Command) error {
-	collectionName := c.Args().Get(0)
-	docs := c.StringSlice("doc")
-
-	if len(docs) == 0 {
-		return fmt.Errorf("no documents provided\n\nUsage: chroma add <collection> --doc \"text\"\n\nExample: chroma add my_collection --doc \"Your document\"")
-	}
-
-	// Setup client
-	client, err := createChromaClient(c)
-	if err != nil {
-		return fmt.Errorf("failed to create Chroma client: %w", err)
-	}
-
-	// Load AI Engine
-	embedder, err := initEmbedder(c)
-	if err != nil {
-		return fmt.Errorf("failed to initialize embedding engine: %w\n\nHint: Verify model files exist", err)
-	}
-
-	svc := service.NewChromaService(client, embedder)
-	defer svc.Close()
-
-	// Handle IDs: use provided ones or generate auto IDs
-	ids := c.StringSlice("id")
-	if len(ids) > 0 {
-		// User provided custom IDs
-		if len(ids) != len(docs) {
-			return fmt.Errorf("number of IDs (%d) must match number of documents (%d)", len(ids), len(docs))
-		}
-
-		slog.Info("Using custom document IDs", "ids", ids)
-	} else {
-		// Generate auto IDs
-		ids = make([]string, len(docs))
-		for i := range docs {
-			ids[i] = fmt.Sprintf("id-%d-%d", time.Now().UnixNano(), i)
-		}
-	}
-
-	// Execute
-	slog.Info("Uploading batch to Chroma", "collection", collectionName, "count", len(docs))
-
-	if err := svc.AddDocuments(collectionName, docs, ids); err != nil {
-		return fmt.Errorf("failed to add documents: %w\n\nHint: Check collection exists and you have write permissions", err)
-	}
-
-	fmt.Printf("✅ Successfully added %d documents to '%s'\n", len(docs), collectionName)
-	slog.Info("Documents added", "collection", collectionName, "count", len(docs))
-
-	return nil
-}
+// ===== Import =====
 
 // handleImportFileInChromaDb imports a file (JSONL or Parquet) with progress tracking.
 func handleImportFileInChromaDb(_ context.Context, c *cli.Command) error {
@@ -572,6 +583,8 @@ func handleImportFileInChromaDb(_ context.Context, c *cli.Command) error {
 	return nil
 }
 
+// ===== RAG Chat =====
+
 // handleChat performs RAG-based question answering.
 func handleChat(_ context.Context, c *cli.Command) error {
 	collectionName := c.Args().Get(0)
@@ -657,6 +670,8 @@ Provide a clear, concise answer:`,
 
 	return nil
 }
+
+// ============ Private Helpers ============
 
 // initEmbedder initializes the ONNX embedder with path resolution.
 func initEmbedder(c *cli.Command) (*onnx.Embedder, error) {

--- a/internal/client/chroma_client.go
+++ b/internal/client/chroma_client.go
@@ -14,6 +14,24 @@ import (
 	"github.com/google/uuid"
 )
 
+// ============ Constants ============
+
+var (
+	cd = internal.CheckDefer
+	// endpoints
+	testEndpoint         = "%s/api/v2/heartbeat"
+	getTenant            = "%s/api/v2/tenants/%s"
+	listDatabases        = "%s/api/v2/tenants/%s/databases"
+	listCreateCollection = "%s/api/v2/tenants/%s/databases/%s/collections"
+	listDocuments        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/get"
+	queryEndpoint        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/query"
+	batchAdd             = "%s/api/v2/tenants/%s/databases/%s/collections/%s/add"
+	deleteCollection     = "%s/api/v2/tenants/%s/databases/%s/collections/%s"
+	deleteRecords        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/delete"
+)
+
+// ============ Core Types ============
+
 type (
 	ChromaClient struct {
 		URL, Tenant, Database string
@@ -36,6 +54,70 @@ type (
 	}
 )
 
+// ============ Data Transfer Types ============
+
+type (
+	CreateCollectionRequest struct {
+		Name        string         `json:"name"`
+		Metadata    map[string]any `json:"metadata"`
+		GetOrCreate bool           `json:"get_or_create"`
+	}
+
+	// Collection represents the detailed response from ChromaDB
+	Collection struct {
+		ID        string         `json:"id"`
+		Name      string         `json:"name"`
+		Tenant    string         `json:"tenant"`
+		Database  string         `json:"database"`
+		Metadata  map[string]any `json:"metadata"`
+		Dimension *int           `json:"dimension"` // Pointer because it can be null
+		Config    map[string]any `json:"configuration_json"`
+	}
+
+	Database struct {
+		Id     string `json:"id"`
+		Name   string `json:"name"`
+		Tenant string `json:"tenant"`
+	}
+
+	GetRecordsRequest struct {
+		Tenant   string   `json:"tenant"`
+		Database string   `json:"database"`
+		IDs      []string `json:"ids,omitempty"`
+		Include  []string `json:"include"`
+		Limit    *int     `json:"limit"`
+		Offset   *int     `json:"offset"`
+	}
+
+	GetRecordsResponse struct {
+		IDs       []string         `json:"ids"`
+		Documents []string         `json:"documents"`
+		Metadatas []map[string]any `json:"metadatas"`
+	}
+
+	AddRecordsRequest struct {
+		IDs        []string         `json:"ids"`
+		Documents  []string         `json:"documents"`
+		Embeddings [][]float32      `json:"embeddings"` // Change: No longer omitempty
+		Metadatas  []map[string]any `json:"metadatas,omitempty"`
+	}
+
+	QueryResponse struct {
+		IDs       [][]string         `json:"ids"`
+		Documents [][]string         `json:"documents"`
+		Metadatas [][]map[string]any `json:"metadatas"`
+		Distances [][]float32        `json:"distances"`
+	}
+
+	IngestRecord struct {
+		ID       string         `json:"id"`
+		Text     string         `json:"text"`
+		Metadata map[string]any `json:"metadata"`
+	}
+)
+
+// ============ Constructor ============
+
 func NewChromaDBClient(url, tenant, database string) *ChromaClient {
 	slog.Info("Initializing Chroma client", "url", url, "tenant", tenant, "database", database)
 
@@ -46,6 +128,8 @@ func NewChromaDBClient(url, tenant, database string) *ChromaClient {
 		client:   &http.Client{},
 	}
 }
+
+// ============ Connection & Health ============
 
 func (c *ChromaClient) TestConnection() error {
 	endpoint := fmt.Sprintf(testEndpoint, c.URL)
@@ -90,6 +174,8 @@ func (c *ChromaClient) GetTenant() (bool, error) {
 	return false, fmt.Errorf("unexpected status: %d", resp.StatusCode)
 }
 
+// ============ Databases ============
+
 func (c *ChromaClient) ListDatabases() ([]Database, error) {
 	// URL includes the specific tenant from your client struct
 	endpoint := fmt.Sprintf(listDatabases, c.URL, c.Tenant)
@@ -114,6 +200,8 @@ func (c *ChromaClient) ListDatabases() ([]Database, error) {
 
 	return databases, nil
 }
+
+// ============ Collections ============
 
 func (c *ChromaClient) ListCollections() ([]Collection, error) {
 	// endpoint
@@ -176,6 +264,8 @@ func (c *ChromaClient) CreateCollection(name string) (string, error) {
 
 	return result.ID, nil
 }
+
+// ============ Documents ============
 
 // ListDocuments - List Documents in collection
 func (c *ChromaClient) ListDocuments(collectionID string) (*GetRecordsResponse, error) {
@@ -260,6 +350,8 @@ func (c *ChromaClient) GetIDByName(name string) (string, error) {
 	return "", fmt.Errorf("collection '%s' not found", name)
 }
 
+// ============ Deletion ============
+
 func (c *ChromaClient) DeleteCollection(name string) error {
 	slog.Info("Deleting collection", "name", name)
 
@@ -325,6 +417,8 @@ func (c *ChromaClient) DeleteRecords(collectionID string, ids []string) error {
 	return nil
 }
 
+// ============ Embedding ============
+
 // AddDocument - Corrected Metadata tag handling
 func (c *ChromaClient) AddDocument(collectionID, id, text string, vector []float32) error {
 	endpoint := fmt.Sprintf(batchAdd,
@@ -365,6 +459,8 @@ func (c *ChromaClient) GenerateLocalEmbedding(text string) ([]float32, error) {
 
 	return vector, nil
 }
+
+// ============ Querying ============
 
 func (c *ChromaClient) QueryBatch(collectionId string, queryTexts []string, nResults int) (*QueryResponse, error) {
 	//1. Generate embeddings for all queries at once
@@ -410,6 +506,8 @@ func (c *ChromaClient) QueryBatch(collectionId string, queryTexts []string, nRes
 
 	return &result, nil
 }
+
+// ============ Batch Operations ============
 
 func (c *ChromaClient) AddBatch(collectionID string, docs []string, ids []string) error {
 	if c.Embedder == nil {
@@ -504,78 +602,3 @@ func (c *ChromaClient) AddBatchGeneric(collectionID string, documents []string, 
 
 	return nil
 }
-
-// Json Parser struct
-type (
-	CreateCollectionRequest struct {
-		Name        string         `json:"name"`
-		Metadata    map[string]any `json:"metadata"`
-		GetOrCreate bool           `json:"get_or_create"`
-	}
-
-	// Collection represents the detailed response from ChromaDB
-	Collection struct {
-		ID        string         `json:"id"`
-		Name      string         `json:"name"`
-		Tenant    string         `json:"tenant"`
-		Database  string         `json:"database"`
-		Metadata  map[string]any `json:"metadata"`
-		Dimension *int           `json:"dimension"` // Pointer because it can be null
-		Config    map[string]any `json:"configuration_json"`
-	}
-
-	Database struct {
-		Id     string `json:"id"`
-		Name   string `json:"name"`
-		Tenant string `json:"tenant"`
-	}
-
-	GetRecordsRequest struct {
-		Tenant   string   `json:"tenant"`
-		Database string   `json:"database"`
-		IDs      []string `json:"ids,omitempty"`
-		Include  []string `json:"include"`
-		Limit    *int     `json:"limit"`
-		Offset   *int     `json:"offset"`
-	}
-
-	GetRecordsResponse struct {
-		IDs       []string         `json:"ids"`
-		Documents []string         `json:"documents"`
-		Metadatas []map[string]any `json:"metadatas"`
-	}
-
-	AddRecordsRequest struct {
-		IDs        []string         `json:"ids"`
-		Documents  []string         `json:"documents"`
-		Embeddings [][]float32      `json:"embeddings"` // Change: No longer omitempty
-		Metadatas  []map[string]any `json:"metadatas,omitempty"`
-	}
-
-	QueryResponse struct {
-		IDs       [][]string         `json:"ids"`
-		Documents [][]string         `json:"documents"`
-		Metadatas [][]map[string]any `json:"metadatas"`
-		Distances [][]float32        `json:"distances"`
-	}
-
-	IngestRecord struct {
-		ID       string         `json:"id"`
-		Text     string         `json:"text"`
-		Metadata map[string]any `json:"metadata"`
-	}
-)
-
-var (
-	cd = internal.CheckDefer
-	// endpoints
-	testEndpoint         = "%s/api/v2/heartbeat"
-	getTenant            = "%s/api/v2/tenants/%s"
-	listDatabases        = "%s/api/v2/tenants/%s/databases"
-	listCreateCollection = "%s/api/v2/tenants/%s/databases/%s/collections"
-	listDocuments        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/get"
-	queryEndpoint        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/query"
-	batchAdd             = "%s/api/v2/tenants/%s/databases/%s/collections/%s/add"
-	deleteCollection     = "%s/api/v2/tenants/%s/databases/%s/collections/%s"
-	deleteRecords        = "%s/api/v2/tenants/%s/databases/%s/collections/%s/delete"
-)

--- a/internal/ingest/manager.go
+++ b/internal/ingest/manager.go
@@ -16,6 +16,8 @@ import (
 	"github.com/parquet-go/parquet-go"
 )
 
+// ============ Data Types ============
+
 type Record struct {
 	ID       string
 	Content  string
@@ -31,16 +33,27 @@ type Config struct {
 	Limit          int      // max records to ingest, 0 = unlimited
 }
 
+type Processor struct {
+	cfg *Config
+}
+
+// Primitive reflect.Kinds that can be kept as-is
+var primitiveTypes = map[reflect.Kind]bool{
+	reflect.String: true,
+	reflect.Int:    true, reflect.Int8: true, reflect.Int16: true, reflect.Int32: true, reflect.Int64: true,
+	reflect.Uint: true, reflect.Uint8: true, reflect.Uint16: true, reflect.Uint32: true, reflect.Uint64: true,
+	reflect.Float32: true, reflect.Float64: true,
+	reflect.Bool: true,
+}
+
+// ============ Constructors ============
+
 func DefaultConfig() *Config {
 	return &Config{
 		BatchSize:    100,
 		ContentField: "text",
 		IDField:      "id",
 	}
-}
-
-type Processor struct {
-	cfg *Config
 }
 
 func NewProcessor(cfg *Config) *Processor {
@@ -51,38 +64,7 @@ func NewProcessor(cfg *Config) *Processor {
 	return &Processor{cfg: cfg}
 }
 
-// primitiveTypes holds a set of reflect.Kind values that are considered primitive
-var primitiveTypes = map[reflect.Kind]bool{
-	reflect.String: true,
-	reflect.Int:    true, reflect.Int8: true, reflect.Int16: true, reflect.Int32: true, reflect.Int64: true,
-	reflect.Uint: true, reflect.Uint8: true, reflect.Uint16: true, reflect.Uint32: true, reflect.Uint64: true,
-	reflect.Float32: true, reflect.Float64: true,
-	reflect.Bool: true,
-}
-
-// stringifyIfComplex converts non-primitive values to strings while preserving primitive types
-func (p *Processor) stringifyIfComplex(value any) any {
-	if value == nil {
-		return nil
-	}
-
-	rt := reflect.TypeOf(value)
-	// Pointers: dereference and check underlying type
-	for rt.Kind() == reflect.Ptr {
-		if value == nil {
-			return nil
-		}
-
-		value = reflect.ValueOf(value).Elem().Interface()
-		rt = reflect.TypeOf(value)
-	}
-	// Check if primitive
-	if primitiveTypes[rt.Kind()] {
-		return value
-	}
-	// Complex type - convert to string
-	return fmt.Sprintf("%v", value)
-}
+// ============ Public Processing Methods ============
 
 // ProcessJSONL reads a JSONL file and streams records through the provided channel.
 // The channel is closed when processing is complete or an unrecoverable error occurs.
@@ -247,7 +229,49 @@ func (p *Processor) ProcessParquet(filePath string) (<-chan *Record, <-chan erro
 	return records, errChan
 }
 
-// extractRecord converts raw JSON map into a Record.
+// ============ Private Helpers ============
+
+// getNestedValue retrieves nested values using dot notation.
+func getNestedValue(m map[string]any, path string) any {
+	parts := strings.Split(path, ".")
+
+	var current any = m
+	for _, part := range parts {
+		if next, ok := current.(map[string]any); ok {
+			current = next[part]
+		} else {
+			return nil
+		}
+	}
+
+	return current
+}
+
+// stringifyIfComplex converts non-primitive values to strings while preserving primitive types.
+func (p *Processor) stringifyIfComplex(value any) any {
+	if value == nil {
+		return nil
+	}
+
+	rt := reflect.TypeOf(value)
+	// Pointers: dereference and check underlying type
+	for rt.Kind() == reflect.Ptr {
+		if value == nil {
+			return nil
+		}
+
+		value = reflect.ValueOf(value).Elem().Interface()
+		rt = reflect.TypeOf(value)
+	}
+	// Check if primitive
+	if primitiveTypes[rt.Kind()] {
+		return value
+	}
+	// Complex type - convert to string
+	return fmt.Sprintf("%v", value)
+}
+
+// extractRecord converts raw JSON/Parquet map into a Record.
 func (p *Processor) extractRecord(raw map[string]any) (*Record, error) {
 	contentVal := getNestedValue(raw, p.cfg.ContentField)
 	if contentVal == nil {
@@ -290,20 +314,4 @@ func (p *Processor) extractRecord(raw map[string]any) (*Record, error) {
 		Content:  content,
 		Metadata: meta,
 	}, nil
-}
-
-// getNestedValue retrieves nested values using dot notation.
-func getNestedValue(m map[string]any, path string) any {
-	parts := strings.Split(path, ".")
-
-	var current any = m
-	for _, part := range parts {
-		if next, ok := current.(map[string]any); ok {
-			current = next[part]
-		} else {
-			return nil
-		}
-	}
-
-	return current
 }

--- a/internal/service/chroma_service.go
+++ b/internal/service/chroma_service.go
@@ -10,11 +10,15 @@ import (
 	"github.com/DONAR-0/cmdChroma/internal/onnx"
 )
 
+// ============ Service Definition ============
+
 // ChromaService handles business logic for ChromaDB operations.
 type ChromaService struct {
 	client   client.ChromaClientInterface
 	embedder onnx.EmbedderInterface
 }
+
+// ============ Constructor ============
 
 // NewChromaService creates a new service with the given client and embedder.
 // If the client is a concrete *client.ChromaClient, the embedder is injected into it.
@@ -32,6 +36,8 @@ func NewChromaService(c client.ChromaClientInterface, e onnx.EmbedderInterface) 
 		embedder: e,
 	}
 }
+
+// ============ Connection & Discovery ============
 
 // TestConnection tests the connection to ChromaDB.
 func (s *ChromaService) TestConnection() error {
@@ -90,6 +96,8 @@ func (s *ChromaService) ListCollections() ([]client.Collection, error) {
 
 	return collections, nil
 }
+
+// ============ Document Operations ============
 
 // AddDocuments adds documents to a collection with embeddings.
 func (s *ChromaService) AddDocuments(collectionName string, docs []string, ids []string) error {
@@ -151,12 +159,16 @@ func (s *ChromaService) QueryDocuments(collectionName string, queries []string, 
 	return result, nil
 }
 
+// ============ Resource Management ============
+
 // Close releases resources used by the service.
 func (s *ChromaService) Close() {
 	if s.embedder != nil {
 		s.embedder.Close()
 	}
 }
+
+// ============ Ingestion ============
 
 // IngestRecords ingests records from a JSONL file into the collection.
 // It parses the file, extracts content and metadata, generates embeddings,
@@ -242,6 +254,8 @@ func (s *ChromaService) IngestRecords(collectionName, filePath string, cfg *inge
 
 	return nil
 }
+
+// ============ Private Helpers ============
 
 // uploadBatch uploads a batch of documents to Chroma.
 // The client's AddBatchGeneric generates embeddings internally.


### PR DESCRIPTION
  This commit addresses two main areas:

  1. GitHub Username Case Correction
     - Fixed case sensitivity issues: donar0 → DONAR-0
     - Updated module path in go.mod to match actual repository location - Corrected all import paths across the codebase - Fixed README.md badge URLs, Docker references, and clone URL - Removed badge for deleted docker.yml workflow

  2. Code Reorganization Using Conventional Go Ordering Applied consistent section-based organization to large files instead of alphabetical ordering (which would break logical grouping):

     • cmd/chroma/handlers.go - Grouped handlers by domain (connection, collections, documents, search, import, RAG) • internal/client/chroma_client.go - Structured with clear sections: constants, types, constructors, and methods by functional area • internal/service/chroma_service.go - Organized service methods by responsibility (connection, document operations, ingestion, etc.) • cmd/chroma/definitions.go - Grouped command and flag definitions • internal/ingest/manager.go - Structured data types, constructors, public methods, and private helpers

  These changes ensure:
  - go get works correctly (module path matches repository)
  - CI badges display properly (correct GitHub org case)
  - Improved code maintainability through consistent organization
  - Clear visual separation of concerns in large files